### PR TITLE
fixes typo on inquire import

### DIFF
--- a/awssso
+++ b/awssso
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 import boto3
-import inquirergit
+import inquirer
 from dateutil.parser import parse
 from dateutil.tz import UTC, tzlocal
 


### PR DESCRIPTION
## Description

Looks like there was a typo in a recent commit that added `git` to the end of the `inquirer` import.

I wasn't able to run `awssso` unless I changed the import to `import inquirer`﻿

<img width="381" alt="Screen Shot 2021-01-09 at 5 39 16 PM" src="https://user-images.githubusercontent.com/8786230/104110881-9e101b00-52a1-11eb-9a3f-fd2861e79201.png">


BTW: great project! 😄 

